### PR TITLE
Added Sass to project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12197,6 +12197,17 @@
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
     },
+    "sass": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
+      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
+      "devOptional": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
+    },
     "sass-loader": {
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
   },
   "devDependencies": {
     "@capacitor/cli": "4.4.0",
-    "@ionic/cli": "6.20.3"
+    "@ionic/cli": "6.20.3",
+    "sass": "^1.56.1"
   },
   "description": "An Ionic project"
 }


### PR DESCRIPTION
Sass allows us to write CSS code easier. For example, if my CSS is:
```css
.chat-input {
  line-height: 20px;
}

.chat-input ion-icon {
  font-size: 20px;
}
```
Sass would be:
```css
.chat-input {
  line-height: $line-var;

  ion-icon {
    font-size: $line-var;
  }
}
```
where `$line-var` is a variable that equals 20px. Both types of files can be used in the project, and Sass files auto-compile using `ionic serve` into CSS files. The only change that needs to be made for those wanting to use Sass is to create a file with the `.scss` extension and import that instead of a `.css` file.