### PR TITLE
13 create view for login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,11 @@ import {
   setupIonicReact
 } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
-import { ellipse, square, triangle } from 'ionicons/icons';
+import { checkmarkCircle, ellipse, square, triangle } from 'ionicons/icons';
 import Tab1 from './pages/Tab1';
 import Tab2 from './pages/Tab2';
 import Tab3 from './pages/Tab3';
+import Login from './pages/login/login';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -41,6 +42,9 @@ const App: React.FC = () => (
     <IonReactRouter>
       <IonTabs>
         <IonRouterOutlet>
+          <Route path="/login">
+            <Login />
+          </Route>
           <Route exact path="/tab1">
             <Tab1 />
           </Route>
@@ -55,6 +59,10 @@ const App: React.FC = () => (
           </Route>
         </IonRouterOutlet>
         <IonTabBar slot="bottom">
+          <IonTabButton tab="login" href="../login">
+            <IonIcon icon={checkmarkCircle} />
+            <IonLabel>Login</IonLabel>
+          </IonTabButton>
           <IonTabButton tab="tab1" href="/tab1">
             <IonIcon icon={triangle} />
             <IonLabel>Tab 1</IonLabel>

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { 
+    IonButton, 
+    IonCol,
+    IonContent,
+    IonHeader,
+    IonInput, 
+    IonItem, 
+    IonLabel, 
+    IonNote,
+    IonRouterLink,
+    IonTitle,
+    IonToolbar
+} from '@ionic/react';
+//import ExploreContainer from '../../components/ExploreContainer';
+import './login.css';
+
+const Login: React.FC = () => {
+    const [username, setUsername] = useState();
+    const [password, setPassword] = useState();
+    const [isTouched, setIsTouched] = useState(false);
+    const [isValid, setIsValid] = useState<boolean>();
+ 
+    // Email Validation Functionality
+    const validateEmail = (email: string) => {
+      return email.match(
+        /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+      );
+    };
+  
+    const validate = (ev: Event) => {
+      const value = (ev.target as HTMLInputElement).value;
+  
+      setIsValid(undefined);
+  
+      if (value === '') return;
+  
+      validateEmail(value) !== null ? setIsValid(true) : setIsValid(false);
+    };
+  
+    const markTouched = () => {
+      setIsTouched(true);
+    };
+
+    // Firebase Login Functionality (to be implemented)
+    function loginUser() {
+        // to be implemented
+        console.log(username, password);
+    }
+  
+    return (
+        <>
+            <IonHeader>
+                <IonToolbar>
+                    <IonTitle>
+                        Login
+                    </IonTitle>
+                </IonToolbar>
+            </IonHeader>
+
+            <IonContent className="ion-padding">
+                <IonItem 
+                    fill="solid" 
+                    className={`${isValid && 'ion-valid'} ${isValid === false && 'ion-invalid'} ${isTouched && 'ion-touched'}`}>
+                    <IonLabel position="floating">Email</IonLabel>
+                    <IonInput type="email" 
+                        onIonInput={ (event: any) => { 
+                            validate(event); 
+                            setUsername(event.target.value);
+                            }
+                        }
+                        onIonBlur={() => markTouched()}>
+                    </IonInput>
+                    <IonNote slot="helper">Enter a valid email</IonNote>
+                    <IonNote slot="error">Invalid email</IonNote>
+                </IonItem>
+
+                <IonItem>
+                    <IonLabel position="floating">Password input</IonLabel>
+                    <IonInput type="password" onIonInput={(event:any) => setPassword(event.target.value)}></IonInput>
+                    <IonRouterLink slot="helper" href="#">Forgot Password?</IonRouterLink>
+                </IonItem>
+
+                <IonCol>
+                    <IonButton onClick={loginUser}>Login</IonButton>
+                </IonCol>
+            </IonContent>
+        </>
+    );
+  }
+
+  export default Login;

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -3,15 +3,18 @@ import {
     IonButton, 
     IonCol,
     IonContent,
-    IonHeader,
+    IonCard,
+    IonCardContent,
+    IonCardHeader,
+    IonCardTitle,
+    IonIcon,
     IonInput, 
     IonItem, 
     IonLabel, 
     IonNote,
     IonRouterLink,
-    IonTitle,
-    IonToolbar
 } from '@ionic/react';
+import { logoGoogle } from "ionicons/icons";
 //import ExploreContainer from '../../components/ExploreContainer';
 import './login.css';
 
@@ -49,44 +52,45 @@ const Login: React.FC = () => {
     }
   
     return (
-        <>
-            <IonHeader>
-                <IonToolbar>
-                    <IonTitle>
-                        Login
-                    </IonTitle>
-                </IonToolbar>
-            </IonHeader>
-
-            <IonContent className="ion-padding">
-                <IonItem 
-                    fill="solid" 
-                    className={`${isValid && 'ion-valid'} ${isValid === false && 'ion-invalid'} ${isTouched && 'ion-touched'}`}>
-                    <IonLabel position="floating">Email</IonLabel>
-                    <IonInput type="email" 
-                        onIonInput={ (event: any) => { 
-                            validate(event); 
-                            setUsername(event.target.value);
+        <IonContent>
+            <IonCard>
+                <IonCardHeader>
+                        <IonCardTitle>Login</IonCardTitle>
+                </IonCardHeader>
+                <IonCardContent>
+                    <IonItem
+                        fill="solid" 
+                        className={`${isValid && 'ion-valid'} ${isValid === false && 'ion-invalid'} ${isTouched && 'ion-touched'}`}>
+                        <IonLabel position="floating">Email</IonLabel>
+                        <IonInput type="email" 
+                            onIonInput={ (event: any) => { 
+                                validate(event); 
+                                setUsername(event.target.value);
+                                }
                             }
-                        }
-                        onIonBlur={() => markTouched()}>
-                    </IonInput>
-                    <IonNote slot="helper">Enter a valid email</IonNote>
-                    <IonNote slot="error">Invalid email</IonNote>
-                </IonItem>
+                            onIonBlur={() => markTouched()}>
+                        </IonInput>
+                        <IonNote slot="helper">Enter a valid email</IonNote>
+                        <IonNote slot="error">Invalid email</IonNote>
+                    </IonItem>
 
-                <IonItem>
-                    <IonLabel position="floating">Password input</IonLabel>
-                    <IonInput type="password" onIonInput={(event:any) => setPassword(event.target.value)}></IonInput>
-                    <IonRouterLink slot="helper" href="#">Forgot Password?</IonRouterLink>
-                </IonItem>
+                    <IonItem fill="solid">
+                        <IonLabel position="floating">Password input</IonLabel>
+                        <IonInput type="password" onIonInput={(event:any) => setPassword(event.target.value)}></IonInput>
+                        <IonRouterLink slot="helper" href="#">Forgot Password?</IonRouterLink>
+                    </IonItem>
 
-                <IonCol>
-                    <IonButton onClick={loginUser}>Login</IonButton>
-                </IonCol>
-            </IonContent>
-        </>
+                    <IonCol>
+                        <IonButton onClick={loginUser}>Login</IonButton>
+                        <IonButton color="tertiary">
+                            <IonIcon icon={logoGoogle}></IonIcon> &nbsp;Sign in with Google
+                        </IonButton>
+                    </IonCol>
+                </IonCardContent>
+            </IonCard>
+        </IonContent>
     );
   }
+
 
   export default Login;


### PR DESCRIPTION
Basic view for login page (with no styling. Would like a meeting to discuss the standardization of formatting, and to get the official branding logos before spending more time with aesthetics).

<img width="651" alt="image" src="https://user-images.githubusercontent.com/36782876/203396740-7c84ff31-04b1-47c2-99b0-750ab5324d05.png">
View from Mobile

<img width="752" alt="image" src="https://user-images.githubusercontent.com/36782876/203396836-88081245-a931-43e3-976c-181d63938d29.png">
View from Desktop
 
<img width="181" alt="image" src="https://user-images.githubusercontent.com/36782876/203396924-4ad762ad-2eb2-4568-8637-61793e6d23b5.png">
Incorrect email formatting

<img width="174" alt="image" src="https://user-images.githubusercontent.com/36782876/203397027-d75907e2-253e-4d70-b50a-6b816f2322e1.png">
Correct email formatting

<img width="177" alt="image" src="https://user-images.githubusercontent.com/36782876/203397096-185eba27-cb68-46dd-a327-511843dd30c3.png">
Password hiding

<img width="934" alt="image" src="https://user-images.githubusercontent.com/36782876/203397175-ed1dfe81-e65b-4c48-9dbf-76a755f7ec0a.png">
On-click of login button captures the username and password (as seen in console log) to be handled by backend team for FB 
